### PR TITLE
Update for reviewer's comment

### DIFF
--- a/src/aiida_wannier90_workflows/utils/pseudo/__init__.py
+++ b/src/aiida_wannier90_workflows/utils/pseudo/__init__.py
@@ -130,6 +130,7 @@ def get_semicore_list(
     # }
     label2num = {"S": 1, "P": 3, "D": 5, "F": 7}
     # for spin-orbit-coupling, every orbit contains 2 electrons
+    nspin = 2 if spin_orbit_coupling else 1
 
     semicore_list = []  # index should start from 1
     num_pswfcs = 0
@@ -140,7 +141,6 @@ def get_semicore_list(
         site_semicores = deepcopy(pseudo_orbitals[site.kind_name]["semicores"])
 
         for orb in site_pswfcs:
-            nspin = 2 if spin_orbit_coupling else 1
             num_orbs = label2num[orb[-1]] * nspin
             if orb in site_semicores:
                 site_semicores.remove(orb)

--- a/src/aiida_wannier90_workflows/utils/pseudo/data/__init__.py
+++ b/src/aiida_wannier90_workflows/utils/pseudo/data/__init__.py
@@ -285,14 +285,14 @@ Pu: Pu.$fct-spfn-*_psl.1.0.0"""
         # copy the pseudopotentials to another folder, which only contain the pp we need
         dst_filename = os.path.join(dir_pseudos_install, filename)
         if dirname is not None:
-            filename = os.path.join(dirname, filename)
-            shutil.copy2(filename, dst_filename)
+            shutil.copy2(os.path.join(dirname, filename), dst_filename)
         else:
             if not os.path.exists(filename):
                 # download from QE website
                 url = qe_site + filename
                 urllib.request.urlretrieve(url, dst_filename)
         result[element] = get_metadata(dst_filename)
+        result[element]["filename"] = filename
     # the output file (as well as the pseudo_install if dirname==None) will be placed in the workdir
     with open(output_filename, "w", encoding="utf-8") as handle:
         json.dump(result, handle, indent=2)

--- a/src/aiida_wannier90_workflows/utils/pseudo/data/semicore/pslibrary_paw_relpbe_1.0.0.json
+++ b/src/aiida_wannier90_workflows/utils/pseudo/data/semicore/pslibrary_paw_relpbe_1.0.0.json
@@ -1,6 +1,6 @@
 {
   "H": {
-    "filename": "pseudo_install/H.rel-pbe-kjpaw_psl.1.0.0.UPF",
+    "filename": "H.rel-pbe-kjpaw_psl.1.0.0.UPF",
     "md5": "037bf403638bd299dbaaf1173eb7767f",
     "pseudopotential": "100PAW",
     "cutoff_wfc": 46.0,
@@ -11,7 +11,7 @@
     "semicores": []
   },
   "He": {
-    "filename": "pseudo_install/He.rel-pbe-kjpaw_psl.1.0.0.UPF",
+    "filename": "He.rel-pbe-kjpaw_psl.1.0.0.UPF",
     "md5": "afe997fbd81e4d085705fc8d3505622d",
     "pseudopotential": "100PAW",
     "cutoff_wfc": 46.0,
@@ -22,7 +22,7 @@
     "semicores": []
   },
   "Li": {
-    "filename": "pseudo_install/Li.rel-pbe-sl-kjpaw_psl.1.0.0.UPF",
+    "filename": "Li.rel-pbe-sl-kjpaw_psl.1.0.0.UPF",
     "md5": "9a8f4f81f428697f6e12a9a20a0b1c43",
     "pseudopotential": "100PAW",
     "cutoff_wfc": 50.0,
@@ -37,7 +37,7 @@
     ]
   },
   "Be": {
-    "filename": "pseudo_install/Be.rel-pbe-sl-kjpaw_psl.1.0.0.UPF",
+    "filename": "Be.rel-pbe-sl-kjpaw_psl.1.0.0.UPF",
     "md5": "1e68d8743e8e6ffa5a3b0a77cc54e2fd",
     "pseudopotential": "100PAW",
     "cutoff_wfc": 70.0,
@@ -52,7 +52,7 @@
     ]
   },
   "B": {
-    "filename": "pseudo_install/B.rel-pbe-n-kjpaw_psl.1.0.0.UPF",
+    "filename": "B.rel-pbe-n-kjpaw_psl.1.0.0.UPF",
     "md5": "a48664298749fd77b6d4a2ac3e2adea4",
     "pseudopotential": "100PAW",
     "cutoff_wfc": 43.0,
@@ -64,7 +64,7 @@
     "semicores": []
   },
   "C": {
-    "filename": "pseudo_install/C.rel-pbe-n-kjpaw_psl.1.0.0.UPF",
+    "filename": "C.rel-pbe-n-kjpaw_psl.1.0.0.UPF",
     "md5": "dd2b8f743de1f3a10095e4114fb28074",
     "pseudopotential": "100PAW",
     "cutoff_wfc": 40.0,
@@ -76,7 +76,7 @@
     "semicores": []
   },
   "N": {
-    "filename": "pseudo_install/N.rel-pbe-n-kjpaw_psl.1.0.0.UPF",
+    "filename": "N.rel-pbe-n-kjpaw_psl.1.0.0.UPF",
     "md5": "ce13193a5f6649a469ffa31f3b7b4cff",
     "pseudopotential": "100PAW",
     "cutoff_wfc": 44.0,
@@ -88,7 +88,7 @@
     "semicores": []
   },
   "O": {
-    "filename": "pseudo_install/O.rel-pbe-n-kjpaw_psl.1.0.0.UPF",
+    "filename": "O.rel-pbe-n-kjpaw_psl.1.0.0.UPF",
     "md5": "8d6a81564d6b023d29e58f26e74c0d2c",
     "pseudopotential": "100PAW",
     "cutoff_wfc": 47.0,
@@ -100,7 +100,7 @@
     "semicores": []
   },
   "F": {
-    "filename": "pseudo_install/F.rel-pbe-n-kjpaw_psl.1.0.0.UPF",
+    "filename": "F.rel-pbe-n-kjpaw_psl.1.0.0.UPF",
     "md5": "aadd520ad1d9d363ccca3cf2760e2cc2",
     "pseudopotential": "100PAW",
     "cutoff_wfc": 49.0,
@@ -112,7 +112,7 @@
     "semicores": []
   },
   "Ne": {
-    "filename": "pseudo_install/Ne.rel-pbe-n-kjpaw_psl.1.0.0.UPF",
+    "filename": "Ne.rel-pbe-n-kjpaw_psl.1.0.0.UPF",
     "md5": "f2a593411650ce398e62eb9459a52a1e",
     "pseudopotential": "100PAW",
     "cutoff_wfc": 54.0,
@@ -124,7 +124,7 @@
     "semicores": []
   },
   "Na": {
-    "filename": "pseudo_install/Na.rel-pbe-spnl-kjpaw_psl.1.0.0.UPF",
+    "filename": "Na.rel-pbe-spnl-kjpaw_psl.1.0.0.UPF",
     "md5": "ab3da668fb837a757098f90f200778bd",
     "pseudopotential": "100PAW",
     "cutoff_wfc": 66.0,
@@ -140,7 +140,7 @@
     ]
   },
   "Mg": {
-    "filename": "pseudo_install/Mg.rel-pbe-spnl-kjpaw_psl.1.0.0.UPF",
+    "filename": "Mg.rel-pbe-spnl-kjpaw_psl.1.0.0.UPF",
     "md5": "8f8702462a0e2779f1456d461402b56f",
     "pseudopotential": "100PAW",
     "cutoff_wfc": 58.0,
@@ -156,7 +156,7 @@
     ]
   },
   "Al": {
-    "filename": "pseudo_install/Al.rel-pbe-nl-kjpaw_psl.1.0.0.UPF",
+    "filename": "Al.rel-pbe-nl-kjpaw_psl.1.0.0.UPF",
     "md5": "8603568e0b092ac6002233ea90ded6aa",
     "pseudopotential": "100PAW",
     "cutoff_wfc": 29.0,
@@ -168,7 +168,7 @@
     "semicores": []
   },
   "Si": {
-    "filename": "pseudo_install/Si.rel-pbe-nl-kjpaw_psl.1.0.0.UPF",
+    "filename": "Si.rel-pbe-nl-kjpaw_psl.1.0.0.UPF",
     "md5": "2f2fadda267dbd22f844df6c3323d5c7",
     "pseudopotential": "100PAW",
     "cutoff_wfc": 44.0,
@@ -180,7 +180,7 @@
     "semicores": []
   },
   "P": {
-    "filename": "pseudo_install/P.rel-pbe-nl-kjpaw_psl.1.0.0.UPF",
+    "filename": "P.rel-pbe-nl-kjpaw_psl.1.0.0.UPF",
     "md5": "7fa0983dd65a922f5b56b305378c65b7",
     "pseudopotential": "100PAW",
     "cutoff_wfc": 34.0,
@@ -192,7 +192,7 @@
     "semicores": []
   },
   "S": {
-    "filename": "pseudo_install/S.rel-pbe-nl-kjpaw_psl.1.0.0.UPF",
+    "filename": "S.rel-pbe-nl-kjpaw_psl.1.0.0.UPF",
     "md5": "1888ec88091fbc32d6e8c9017227a460",
     "pseudopotential": "100PAW",
     "cutoff_wfc": 39.0,
@@ -204,7 +204,7 @@
     "semicores": []
   },
   "Cl": {
-    "filename": "pseudo_install/Cl.rel-pbe-nl-kjpaw_psl.1.0.0.UPF",
+    "filename": "Cl.rel-pbe-nl-kjpaw_psl.1.0.0.UPF",
     "md5": "1aaa40c4a7006a23baa36134b47c89fd",
     "pseudopotential": "100PAW",
     "cutoff_wfc": 46.0,
@@ -216,7 +216,7 @@
     "semicores": []
   },
   "Ar": {
-    "filename": "pseudo_install/Ar.rel-pbe-n-kjpaw_psl.1.0.0.UPF",
+    "filename": "Ar.rel-pbe-n-kjpaw_psl.1.0.0.UPF",
     "md5": "7bff8f0fe67f22b55e13dff25e0eb763",
     "pseudopotential": "100PAW",
     "cutoff_wfc": 48.0,
@@ -228,7 +228,7 @@
     "semicores": []
   },
   "K": {
-    "filename": "pseudo_install/K.rel-pbe-spn-kjpaw_psl.1.0.0.UPF",
+    "filename": "K.rel-pbe-spn-kjpaw_psl.1.0.0.UPF",
     "md5": "9d8319e24d37a63b3f5001d557e1418a",
     "pseudopotential": "100PAW",
     "cutoff_wfc": 41.0,
@@ -245,7 +245,7 @@
     ]
   },
   "Ca": {
-    "filename": "pseudo_install/Ca.rel-pbe-spn-kjpaw_psl.1.0.0.UPF",
+    "filename": "Ca.rel-pbe-spn-kjpaw_psl.1.0.0.UPF",
     "md5": "72fbe3e93cd36ebee05e133e448dce26",
     "pseudopotential": "100PAW",
     "cutoff_wfc": 45.0,
@@ -262,7 +262,7 @@
     ]
   },
   "Sc": {
-    "filename": "pseudo_install/Sc.rel-pbe-spn-kjpaw_psl.1.0.0.UPF",
+    "filename": "Sc.rel-pbe-spn-kjpaw_psl.1.0.0.UPF",
     "md5": "552fa75300d239cdb4413d1eac98d48c",
     "pseudopotential": "100PAW",
     "cutoff_wfc": 50.0,
@@ -279,7 +279,7 @@
     ]
   },
   "Ti": {
-    "filename": "pseudo_install/Ti.rel-pbe-spn-kjpaw_psl.1.0.0.UPF",
+    "filename": "Ti.rel-pbe-spn-kjpaw_psl.1.0.0.UPF",
     "md5": "cc20945288f03d965ca1bdfdb5c7af61",
     "pseudopotential": "100PAW",
     "cutoff_wfc": 52.0,
@@ -296,7 +296,7 @@
     ]
   },
   "V": {
-    "filename": "pseudo_install/V.rel-pbe-spnl-kjpaw_psl.1.0.0.UPF",
+    "filename": "V.rel-pbe-spnl-kjpaw_psl.1.0.0.UPF",
     "md5": "e977907b3d84fd67c1b4d432f1cac99b",
     "pseudopotential": "100PAW",
     "cutoff_wfc": 48.0,
@@ -313,7 +313,7 @@
     ]
   },
   "Cr": {
-    "filename": "pseudo_install/Cr.rel-pbe-spn-kjpaw_psl.1.0.0.UPF",
+    "filename": "Cr.rel-pbe-spn-kjpaw_psl.1.0.0.UPF",
     "md5": "1e24e2b5251376a8b945118fca0c7981",
     "pseudopotential": "100PAW",
     "cutoff_wfc": 48.0,
@@ -330,7 +330,7 @@
     ]
   },
   "Mn": {
-    "filename": "pseudo_install/Mn.rel-pbe-spn-kjpaw_psl.0.3.1.UPF",
+    "filename": "Mn.rel-pbe-spn-kjpaw_psl.0.3.1.UPF",
     "md5": "dfba1c7561257014502ac20495784078",
     "pseudopotential": "100PAW",
     "cutoff_wfc": 46.0,
@@ -347,7 +347,7 @@
     ]
   },
   "Fe": {
-    "filename": "pseudo_install/Fe.rel-pbe-spn-kjpaw_psl.1.0.0.UPF",
+    "filename": "Fe.rel-pbe-spn-kjpaw_psl.1.0.0.UPF",
     "md5": "35347985ef08859638de3692e9baaf78",
     "pseudopotential": "100PAW",
     "cutoff_wfc": 71.0,
@@ -364,7 +364,7 @@
     ]
   },
   "Co": {
-    "filename": "pseudo_install/Co.rel-pbe-spn-kjpaw_psl.0.3.1.UPF",
+    "filename": "Co.rel-pbe-spn-kjpaw_psl.0.3.1.UPF",
     "md5": "c7d2b4999b9b1346d82f91e66db16ece",
     "pseudopotential": "100PAW",
     "cutoff_wfc": 60.0,
@@ -381,7 +381,7 @@
     ]
   },
   "Ni": {
-    "filename": "pseudo_install/Ni.rel-pbe-spn-kjpaw_psl.1.0.0.UPF",
+    "filename": "Ni.rel-pbe-spn-kjpaw_psl.1.0.0.UPF",
     "md5": "14b1cfadbfd847dd2c10390e1efa1736",
     "pseudopotential": "100PAW",
     "cutoff_wfc": 75.0,
@@ -398,7 +398,7 @@
     ]
   },
   "Cu": {
-    "filename": "pseudo_install/Cu.rel-pbe-dn-kjpaw_psl.1.0.0.UPF",
+    "filename": "Cu.rel-pbe-dn-kjpaw_psl.1.0.0.UPF",
     "md5": "685c458065e0290f618c4a0502362fc1",
     "pseudopotential": "100PAW",
     "cutoff_wfc": 45.0,
@@ -411,7 +411,7 @@
     "semicores": []
   },
   "Zn": {
-    "filename": "pseudo_install/Zn.rel-pbe-dnl-kjpaw_psl.1.0.0.UPF",
+    "filename": "Zn.rel-pbe-dnl-kjpaw_psl.1.0.0.UPF",
     "md5": "fb1d41a37581caea8740f542fa3410bf",
     "pseudopotential": "100PAW",
     "cutoff_wfc": 44.0,
@@ -424,7 +424,7 @@
     "semicores": []
   },
   "Ga": {
-    "filename": "pseudo_install/Ga.rel-pbe-dnl-kjpaw_psl.1.0.0.UPF",
+    "filename": "Ga.rel-pbe-dnl-kjpaw_psl.1.0.0.UPF",
     "md5": "b08e22b1d37c8cde44286e4f80e41096",
     "pseudopotential": "100PAW",
     "cutoff_wfc": 44.0,
@@ -439,7 +439,7 @@
     ]
   },
   "Ge": {
-    "filename": "pseudo_install/Ge.rel-pbe-n-kjpaw_psl.1.0.0.UPF",
+    "filename": "Ge.rel-pbe-n-kjpaw_psl.1.0.0.UPF",
     "md5": "b5873b046eebfd6239f19c32a73b61dd",
     "pseudopotential": "100PAW",
     "cutoff_wfc": 20.0,
@@ -451,7 +451,7 @@
     "semicores": []
   },
   "As": {
-    "filename": "pseudo_install/As.rel-pbe-n-kjpaw_psl.1.0.0.UPF",
+    "filename": "As.rel-pbe-n-kjpaw_psl.1.0.0.UPF",
     "md5": "64fce746f52c6128fdf7901f08bfcabb",
     "pseudopotential": "100PAW",
     "cutoff_wfc": 20.0,
@@ -463,7 +463,7 @@
     "semicores": []
   },
   "Se": {
-    "filename": "pseudo_install/Se.rel-pbe-n-kjpaw_psl.1.0.0.UPF",
+    "filename": "Se.rel-pbe-n-kjpaw_psl.1.0.0.UPF",
     "md5": "c57aeb42e1736c5d96bbb16beed8c03e",
     "pseudopotential": "100PAW",
     "cutoff_wfc": 22.0,
@@ -475,7 +475,7 @@
     "semicores": []
   },
   "Br": {
-    "filename": "pseudo_install/Br.rel-pbe-n-kjpaw_psl.1.0.0.UPF",
+    "filename": "Br.rel-pbe-n-kjpaw_psl.1.0.0.UPF",
     "md5": "607cf9a8bc29ab81ba9cc3e40c68b5e9",
     "pseudopotential": "100PAW",
     "cutoff_wfc": 49.0,
@@ -487,7 +487,7 @@
     "semicores": []
   },
   "Kr": {
-    "filename": "pseudo_install/Kr.rel-pbe-dn-kjpaw_psl.1.0.0.UPF",
+    "filename": "Kr.rel-pbe-dn-kjpaw_psl.1.0.0.UPF",
     "md5": "2b9a82e44cb7692ad01e4a272cc510b7",
     "pseudopotential": "100PAW",
     "cutoff_wfc": 63.0,
@@ -502,7 +502,7 @@
     ]
   },
   "Rb": {
-    "filename": "pseudo_install/Rb.rel-pbe-spn-kjpaw_psl.1.0.0.UPF",
+    "filename": "Rb.rel-pbe-spn-kjpaw_psl.1.0.0.UPF",
     "md5": "f262b9acce4965c94454ac3028ead90f",
     "pseudopotential": "100PAW",
     "cutoff_wfc": 35.0,
@@ -519,7 +519,7 @@
     ]
   },
   "Sr": {
-    "filename": "pseudo_install/Sr.rel-pbe-spn-kjpaw_psl.1.0.0.UPF",
+    "filename": "Sr.rel-pbe-spn-kjpaw_psl.1.0.0.UPF",
     "md5": "29a0b1eb8c76fb9ad17737588e801ee1",
     "pseudopotential": "100PAW",
     "cutoff_wfc": 39.0,
@@ -536,7 +536,7 @@
     ]
   },
   "Y": {
-    "filename": "pseudo_install/Y.rel-pbe-spn-kjpaw_psl.1.0.0.UPF",
+    "filename": "Y.rel-pbe-spn-kjpaw_psl.1.0.0.UPF",
     "md5": "fd680bd0e1485fe407cd35146ec60b30",
     "pseudopotential": "100PAW",
     "cutoff_wfc": 39.0,
@@ -554,7 +554,7 @@
     ]
   },
   "Zr": {
-    "filename": "pseudo_install/Zr.rel-pbe-spn-kjpaw_psl.1.0.0.UPF",
+    "filename": "Zr.rel-pbe-spn-kjpaw_psl.1.0.0.UPF",
     "md5": "1e2ec7b1d5fa9b223e51cddc9b0ada63",
     "pseudopotential": "100PAW",
     "cutoff_wfc": 46.0,
@@ -572,7 +572,7 @@
     ]
   },
   "Nb": {
-    "filename": "pseudo_install/Nb.rel-pbe-spn-kjpaw_psl.1.0.0.UPF",
+    "filename": "Nb.rel-pbe-spn-kjpaw_psl.1.0.0.UPF",
     "md5": "2306cb666db741a7975d44936f4113f9",
     "pseudopotential": "100PAW",
     "cutoff_wfc": 48.0,
@@ -590,7 +590,7 @@
     ]
   },
   "Mo": {
-    "filename": "pseudo_install/Mo.rel-pbe-spn-kjpaw_psl.1.0.0.UPF",
+    "filename": "Mo.rel-pbe-spn-kjpaw_psl.1.0.0.UPF",
     "md5": "6cda9dff73cdab358834687290e4775f",
     "pseudopotential": "100PAW",
     "cutoff_wfc": 49.0,
@@ -607,7 +607,7 @@
     ]
   },
   "Tc": {
-    "filename": "pseudo_install/Tc.rel-pbe-spn-kjpaw_psl.0.3.0.UPF",
+    "filename": "Tc.rel-pbe-spn-kjpaw_psl.0.3.0.UPF",
     "md5": "5f2582970073318d70d8745f885458ea",
     "pseudopotential": "100PAW",
     "cutoff_wfc": 63.0,
@@ -625,7 +625,7 @@
     ]
   },
   "Ru": {
-    "filename": "pseudo_install/Ru.rel-pbe-spn-kjpaw_psl.1.0.0.UPF",
+    "filename": "Ru.rel-pbe-spn-kjpaw_psl.1.0.0.UPF",
     "md5": "bef6ff591f01cbcb98cd5c3cd9671440",
     "pseudopotential": "100PAW",
     "cutoff_wfc": 52.0,
@@ -642,7 +642,7 @@
     ]
   },
   "Rh": {
-    "filename": "pseudo_install/Rh.rel-pbe-spn-kjpaw_psl.1.0.0.UPF",
+    "filename": "Rh.rel-pbe-spn-kjpaw_psl.1.0.0.UPF",
     "md5": "be0a2eb4ef258aa3684c35caeb929b78",
     "pseudopotential": "100PAW",
     "cutoff_wfc": 54.0,
@@ -659,7 +659,7 @@
     ]
   },
   "Pd": {
-    "filename": "pseudo_install/Pd.rel-pbe-n-kjpaw_psl.1.0.0.UPF",
+    "filename": "Pd.rel-pbe-n-kjpaw_psl.1.0.0.UPF",
     "md5": "a714dc8e170841c784d7b7259c5b8e99",
     "pseudopotential": "100PAW",
     "cutoff_wfc": 37.0,
@@ -672,7 +672,7 @@
     "semicores": []
   },
   "Ag": {
-    "filename": "pseudo_install/Ag.rel-pbe-n-kjpaw_psl.1.0.0.UPF",
+    "filename": "Ag.rel-pbe-n-kjpaw_psl.1.0.0.UPF",
     "md5": "3d80c1377587b16f7a0a130fe984ec3c",
     "pseudopotential": "100PAW",
     "cutoff_wfc": 45.0,
@@ -685,7 +685,7 @@
     "semicores": []
   },
   "Cd": {
-    "filename": "pseudo_install/Cd.rel-pbe-n-kjpaw_psl.1.0.0.UPF",
+    "filename": "Cd.rel-pbe-n-kjpaw_psl.1.0.0.UPF",
     "md5": "a93254e88be9606c5d1c3af865ba934e",
     "pseudopotential": "100PAW",
     "cutoff_wfc": 37.0,
@@ -698,7 +698,7 @@
     "semicores": []
   },
   "In": {
-    "filename": "pseudo_install/In.rel-pbe-dn-kjpaw_psl.1.0.0.UPF",
+    "filename": "In.rel-pbe-dn-kjpaw_psl.1.0.0.UPF",
     "md5": "ec524eff3d3f5f608c97c0d1a988d36f",
     "pseudopotential": "100PAW",
     "cutoff_wfc": 41.0,
@@ -713,7 +713,7 @@
     ]
   },
   "Sn": {
-    "filename": "pseudo_install/Sn.rel-pbe-dn-kjpaw_psl.1.0.0.UPF",
+    "filename": "Sn.rel-pbe-dn-kjpaw_psl.1.0.0.UPF",
     "md5": "6bcaba2b82cf8d008985ef5bb9854e68",
     "pseudopotential": "100PAW",
     "cutoff_wfc": 47.0,
@@ -728,7 +728,7 @@
     ]
   },
   "Sb": {
-    "filename": "pseudo_install/Sb.rel-pbe-n-kjpaw_psl.1.0.0.UPF",
+    "filename": "Sb.rel-pbe-n-kjpaw_psl.1.0.0.UPF",
     "md5": "fdb47162c1d03e2226be93e80d85f130",
     "pseudopotential": "100PAW",
     "cutoff_wfc": 27.0,
@@ -740,7 +740,7 @@
     "semicores": []
   },
   "Te": {
-    "filename": "pseudo_install/Te.rel-pbe-n-kjpaw_psl.1.0.0.UPF",
+    "filename": "Te.rel-pbe-n-kjpaw_psl.1.0.0.UPF",
     "md5": "6ffde90f16471d786941b44326de665d",
     "pseudopotential": "100PAW",
     "cutoff_wfc": 32.0,
@@ -752,7 +752,7 @@
     "semicores": []
   },
   "I": {
-    "filename": "pseudo_install/I.rel-pbe-n-kjpaw_psl.1.0.0.UPF",
+    "filename": "I.rel-pbe-n-kjpaw_psl.1.0.0.UPF",
     "md5": "1650324410fde579213a6e5684c4bdbf",
     "pseudopotential": "100PAW",
     "cutoff_wfc": 37.0,
@@ -764,7 +764,7 @@
     "semicores": []
   },
   "Xe": {
-    "filename": "pseudo_install/Xe.rel-pbe-dn-kjpaw_psl.1.0.0.UPF",
+    "filename": "Xe.rel-pbe-dn-kjpaw_psl.1.0.0.UPF",
     "md5": "10097592cf2890105a7512c6ff9f6bd2",
     "pseudopotential": "100PAW",
     "cutoff_wfc": 45.0,
@@ -779,7 +779,7 @@
     ]
   },
   "Cs": {
-    "filename": "pseudo_install/Cs.rel-pbe-spn-kjpaw_psl.1.0.0.UPF",
+    "filename": "Cs.rel-pbe-spn-kjpaw_psl.1.0.0.UPF",
     "md5": "a112b951ec9e765992cdd678db6f3609",
     "pseudopotential": "100PAW",
     "cutoff_wfc": 34.0,
@@ -795,7 +795,7 @@
     ]
   },
   "Ba": {
-    "filename": "pseudo_install/Ba.rel-pbe-spn-kjpaw_psl.1.0.0.UPF",
+    "filename": "Ba.rel-pbe-spn-kjpaw_psl.1.0.0.UPF",
     "md5": "e0a6704b63fd109dcd1beae34e497b38",
     "pseudopotential": "100PAW",
     "cutoff_wfc": 38.0,
@@ -811,7 +811,7 @@
     ]
   },
   "La": {
-    "filename": "pseudo_install/La.rel-pbe-spfn-kjpaw_psl.1.0.0.UPF",
+    "filename": "La.rel-pbe-spfn-kjpaw_psl.1.0.0.UPF",
     "md5": "b0542c53e79b904402c04089a938eaf7",
     "pseudopotential": "100PAW",
     "cutoff_wfc": 75.0,
@@ -830,7 +830,7 @@
     ]
   },
   "Ce": {
-    "filename": "pseudo_install/Ce.rel-pbe-spdn-kjpaw_psl.1.0.0.UPF",
+    "filename": "Ce.rel-pbe-spdn-kjpaw_psl.1.0.0.UPF",
     "md5": "ac0589d7a8aa323f6f089402d08f5237",
     "pseudopotential": "100PAW",
     "cutoff_wfc": 37.0,
@@ -848,7 +848,7 @@
     ]
   },
   "Pr": {
-    "filename": "pseudo_install/Pr.rel-pbe-spdn-kjpaw_psl.1.0.0.UPF",
+    "filename": "Pr.rel-pbe-spdn-kjpaw_psl.1.0.0.UPF",
     "md5": "bb1b2b058161422b68becb8df0d1f262",
     "pseudopotential": "100PAW",
     "cutoff_wfc": 41.0,
@@ -866,7 +866,7 @@
     ]
   },
   "Nd": {
-    "filename": "pseudo_install/Nd.rel-pbe-spdn-kjpaw_psl.1.0.0.UPF",
+    "filename": "Nd.rel-pbe-spdn-kjpaw_psl.1.0.0.UPF",
     "md5": "6ff95a8fee99aa3d44d5d8ac73bb2e80",
     "pseudopotential": "100PAW",
     "cutoff_wfc": 38.0,
@@ -884,7 +884,7 @@
     ]
   },
   "Pm": {
-    "filename": "pseudo_install/Pm.rel-pbe-spdn-kjpaw_psl.1.0.0.UPF",
+    "filename": "Pm.rel-pbe-spdn-kjpaw_psl.1.0.0.UPF",
     "md5": "a2e5bc1f9393ebaa72fc7e86f1554155",
     "pseudopotential": "100PAW",
     "cutoff_wfc": 34.0,
@@ -902,7 +902,7 @@
     ]
   },
   "Sm": {
-    "filename": "pseudo_install/Sm.rel-pbe-spdn-kjpaw_psl.1.0.0.UPF",
+    "filename": "Sm.rel-pbe-spdn-kjpaw_psl.1.0.0.UPF",
     "md5": "b6519f5cc08770db5cfae66c810ff3b8",
     "pseudopotential": "100PAW",
     "cutoff_wfc": 34.0,
@@ -920,7 +920,7 @@
     ]
   },
   "Eu": {
-    "filename": "pseudo_install/Eu.rel-pbe-spn-kjpaw_psl.1.0.0.UPF",
+    "filename": "Eu.rel-pbe-spn-kjpaw_psl.1.0.0.UPF",
     "md5": "0f4890f90715dec083c371bcc9b256a7",
     "pseudopotential": "100PAW",
     "cutoff_wfc": 34.0,
@@ -938,7 +938,7 @@
     ]
   },
   "Gd": {
-    "filename": "pseudo_install/Gd.rel-pbe-spdn-kjpaw_psl.1.0.0.UPF",
+    "filename": "Gd.rel-pbe-spdn-kjpaw_psl.1.0.0.UPF",
     "md5": "cf50ec46d1536b4a0251694df1946a53",
     "pseudopotential": "100PAW",
     "cutoff_wfc": 35.0,
@@ -956,7 +956,7 @@
     ]
   },
   "Tb": {
-    "filename": "pseudo_install/Tb.rel-pbe-spdn-kjpaw_psl.1.0.0.UPF",
+    "filename": "Tb.rel-pbe-spdn-kjpaw_psl.1.0.0.UPF",
     "md5": "700eebc4f50079decd557a28dc109dda",
     "pseudopotential": "100PAW",
     "cutoff_wfc": 37.0,
@@ -974,7 +974,7 @@
     ]
   },
   "Dy": {
-    "filename": "pseudo_install/Dy.rel-pbe-spdn-kjpaw_psl.1.0.0.UPF",
+    "filename": "Dy.rel-pbe-spdn-kjpaw_psl.1.0.0.UPF",
     "md5": "42720cd9d253473921ac26539f12d6ce",
     "pseudopotential": "100PAW",
     "cutoff_wfc": 38.0,
@@ -992,7 +992,7 @@
     ]
   },
   "Ho": {
-    "filename": "pseudo_install/Ho.rel-pbe-spdn-kjpaw_psl.1.0.0.UPF",
+    "filename": "Ho.rel-pbe-spdn-kjpaw_psl.1.0.0.UPF",
     "md5": "4e7d248ab65f475caafadc0ff536b909",
     "pseudopotential": "100PAW",
     "cutoff_wfc": 39.0,
@@ -1010,7 +1010,7 @@
     ]
   },
   "Er": {
-    "filename": "pseudo_install/Er.rel-pbe-spdn-kjpaw_psl.1.0.0.UPF",
+    "filename": "Er.rel-pbe-spdn-kjpaw_psl.1.0.0.UPF",
     "md5": "8c298ca11345cf5d9b596ed50b214319",
     "pseudopotential": "100PAW",
     "cutoff_wfc": 41.0,
@@ -1028,7 +1028,7 @@
     ]
   },
   "Tm": {
-    "filename": "pseudo_install/Tm.rel-pbe-spdn-kjpaw_psl.1.0.0.UPF",
+    "filename": "Tm.rel-pbe-spdn-kjpaw_psl.1.0.0.UPF",
     "md5": "5d7679c4767fe0044790657f41612833",
     "pseudopotential": "100PAW",
     "cutoff_wfc": 42.0,
@@ -1046,7 +1046,7 @@
     ]
   },
   "Yb": {
-    "filename": "pseudo_install/Yb.rel-pbe-spn-kjpaw_psl.1.0.0.UPF",
+    "filename": "Yb.rel-pbe-spn-kjpaw_psl.1.0.0.UPF",
     "md5": "0fbbf752bbc253549dc5dfd7522b5c46",
     "pseudopotential": "100PAW",
     "cutoff_wfc": 41.0,
@@ -1064,7 +1064,7 @@
     ]
   },
   "Lu": {
-    "filename": "pseudo_install/Lu.rel-pbe-spdn-kjpaw_psl.1.0.0.UPF",
+    "filename": "Lu.rel-pbe-spdn-kjpaw_psl.1.0.0.UPF",
     "md5": "fad49a86ec33ae00582513928e6a0c76",
     "pseudopotential": "100PAW",
     "cutoff_wfc": 46.0,
@@ -1082,7 +1082,7 @@
     ]
   },
   "Hf": {
-    "filename": "pseudo_install/Hf.rel-pbe-spn-kjpaw_psl.1.0.0.UPF",
+    "filename": "Hf.rel-pbe-spn-kjpaw_psl.1.0.0.UPF",
     "md5": "8ce506c0f46fc2cc302dfd56fbe7bf7a",
     "pseudopotential": "100PAW",
     "cutoff_wfc": 47.0,
@@ -1099,7 +1099,7 @@
     ]
   },
   "Ta": {
-    "filename": "pseudo_install/Ta.rel-pbe-spn-kjpaw_psl.1.0.0.UPF",
+    "filename": "Ta.rel-pbe-spn-kjpaw_psl.1.0.0.UPF",
     "md5": "6e1ba5769453fa802ec161040803b94f",
     "pseudopotential": "100PAW",
     "cutoff_wfc": 44.0,
@@ -1116,7 +1116,7 @@
     ]
   },
   "W": {
-    "filename": "pseudo_install/W.rel-pbe-spn-kjpaw_psl.1.0.0.UPF",
+    "filename": "W.rel-pbe-spn-kjpaw_psl.1.0.0.UPF",
     "md5": "51235a9978e123729cef7a6d558439d4",
     "pseudopotential": "100PAW",
     "cutoff_wfc": 55.0,
@@ -1134,7 +1134,7 @@
     ]
   },
   "Re": {
-    "filename": "pseudo_install/Re.rel-pbe-spn-kjpaw_psl.1.0.0.UPF",
+    "filename": "Re.rel-pbe-spn-kjpaw_psl.1.0.0.UPF",
     "md5": "bab10902f3fc225f315186e6d4fb561d",
     "pseudopotential": "100PAW",
     "cutoff_wfc": 54.0,
@@ -1151,7 +1151,7 @@
     ]
   },
   "Os": {
-    "filename": "pseudo_install/Os.rel-pbe-spn-kjpaw_psl.1.0.0.UPF",
+    "filename": "Os.rel-pbe-spn-kjpaw_psl.1.0.0.UPF",
     "md5": "51c2f091ef93c19d3c8bc1be2c896382",
     "pseudopotential": "100PAW",
     "cutoff_wfc": 54.0,
@@ -1168,7 +1168,7 @@
     ]
   },
   "Ir": {
-    "filename": "pseudo_install/Ir.rel-pbe-n-kjpaw_psl.0.2.3.UPF",
+    "filename": "Ir.rel-pbe-n-kjpaw_psl.0.2.3.UPF",
     "md5": "7464b96378ac869c952ab691ff2c142a",
     "pseudopotential": "100PAW",
     "cutoff_wfc": 40.0,
@@ -1181,7 +1181,7 @@
     "semicores": []
   },
   "Pt": {
-    "filename": "pseudo_install/Pt.rel-pbe-n-kjpaw_psl.1.0.0.UPF",
+    "filename": "Pt.rel-pbe-n-kjpaw_psl.1.0.0.UPF",
     "md5": "0dcc0e6bd842dd014541fe5e1bebba10",
     "pseudopotential": "100PAW",
     "cutoff_wfc": 40.0,
@@ -1194,7 +1194,7 @@
     "semicores": []
   },
   "Au": {
-    "filename": "pseudo_install/Au.rel-pbe-n-kjpaw_psl.1.0.0.UPF",
+    "filename": "Au.rel-pbe-n-kjpaw_psl.1.0.0.UPF",
     "md5": "b87bb77ae6867f007b35a4e582de23d4",
     "pseudopotential": "100PAW",
     "cutoff_wfc": 42.0,
@@ -1207,7 +1207,7 @@
     "semicores": []
   },
   "Hg": {
-    "filename": "pseudo_install/Hg.rel-pbe-n-kjpaw_psl.1.0.0.UPF",
+    "filename": "Hg.rel-pbe-n-kjpaw_psl.1.0.0.UPF",
     "md5": "6e7b0decf2762d189d0a600be1e5846d",
     "pseudopotential": "100PAW",
     "cutoff_wfc": 43.0,
@@ -1220,7 +1220,7 @@
     "semicores": []
   },
   "Tl": {
-    "filename": "pseudo_install/Tl.rel-pbe-dn-kjpaw_psl.1.0.0.UPF",
+    "filename": "Tl.rel-pbe-dn-kjpaw_psl.1.0.0.UPF",
     "md5": "add605f074e4fa0ec7ec06e2454b19f5",
     "pseudopotential": "100PAW",
     "cutoff_wfc": 45.0,
@@ -1235,7 +1235,7 @@
     ]
   },
   "Pb": {
-    "filename": "pseudo_install/Pb.rel-pbe-dn-kjpaw_psl.1.0.0.UPF",
+    "filename": "Pb.rel-pbe-dn-kjpaw_psl.1.0.0.UPF",
     "md5": "e49cd5e0d5070c0a75e92fa0a9ace710",
     "pseudopotential": "100PAW",
     "cutoff_wfc": 46.0,
@@ -1250,7 +1250,7 @@
     ]
   },
   "Bi": {
-    "filename": "pseudo_install/Bi.rel-pbe-dn-kjpaw_psl.1.0.0.UPF",
+    "filename": "Bi.rel-pbe-dn-kjpaw_psl.1.0.0.UPF",
     "md5": "a2fd874d7f712db44af558c1e47d3b28",
     "pseudopotential": "100PAW",
     "cutoff_wfc": 45.0,
@@ -1265,7 +1265,7 @@
     ]
   },
   "Po": {
-    "filename": "pseudo_install/Po.rel-pbe-dn-kjpaw_psl.1.0.0.UPF",
+    "filename": "Po.rel-pbe-dn-kjpaw_psl.1.0.0.UPF",
     "md5": "c1d82601782829f2bd78463fb241e97a",
     "pseudopotential": "100PAW",
     "cutoff_wfc": 85.0,
@@ -1280,7 +1280,7 @@
     ]
   },
   "At": {
-    "filename": "pseudo_install/At.rel-pbe-dn-kjpaw_psl.1.0.0.UPF",
+    "filename": "At.rel-pbe-dn-kjpaw_psl.1.0.0.UPF",
     "md5": "c0dd30d4e93ba7514619d0c6dc065c5a",
     "pseudopotential": "100PAW",
     "cutoff_wfc": 50.0,
@@ -1295,7 +1295,7 @@
     ]
   },
   "Rn": {
-    "filename": "pseudo_install/Rn.rel-pbe-dn-kjpaw_psl.1.0.0.UPF",
+    "filename": "Rn.rel-pbe-dn-kjpaw_psl.1.0.0.UPF",
     "md5": "1156f8d53df07c76c6e1eccde6d42143",
     "pseudopotential": "100PAW",
     "cutoff_wfc": 50.0,
@@ -1310,7 +1310,7 @@
     ]
   },
   "Fr": {
-    "filename": "pseudo_install/Fr.rel-pbe-spdn-kjpaw_psl.1.0.0.UPF",
+    "filename": "Fr.rel-pbe-spdn-kjpaw_psl.1.0.0.UPF",
     "md5": "0e717d8e6ffb84a12ff4b3ea0f1965c0",
     "pseudopotential": "100PAW",
     "cutoff_wfc": 67.0,
@@ -1328,7 +1328,7 @@
     ]
   },
   "Ra": {
-    "filename": "pseudo_install/Ra.rel-pbe-spdn-kjpaw_psl.1.0.0.UPF",
+    "filename": "Ra.rel-pbe-spdn-kjpaw_psl.1.0.0.UPF",
     "md5": "a50650454229b68ce33d2bac4ee18716",
     "pseudopotential": "100PAW",
     "cutoff_wfc": 82.0,
@@ -1346,7 +1346,7 @@
     ]
   },
   "Ac": {
-    "filename": "pseudo_install/Ac.rel-pbe-spfn-kjpaw_psl.1.0.0.UPF",
+    "filename": "Ac.rel-pbe-spfn-kjpaw_psl.1.0.0.UPF",
     "md5": "e8e3517250e7f5db38a4f823e9d8df7b",
     "pseudopotential": "100PAW",
     "cutoff_wfc": 48.0,
@@ -1364,7 +1364,7 @@
     ]
   },
   "Th": {
-    "filename": "pseudo_install/Th.rel-pbe-spfn-kjpaw_psl.1.0.0.UPF",
+    "filename": "Th.rel-pbe-spfn-kjpaw_psl.1.0.0.UPF",
     "md5": "41f00f31c519dd19b3c396b9be9857e8",
     "pseudopotential": "100PAW",
     "cutoff_wfc": 103.0,
@@ -1382,7 +1382,7 @@
     ]
   },
   "Pa": {
-    "filename": "pseudo_install/Pa.rel-pbe-spfn-kjpaw_psl.1.0.0.UPF",
+    "filename": "Pa.rel-pbe-spfn-kjpaw_psl.1.0.0.UPF",
     "md5": "5ae4273d92b79b6f3060f74e478631c9",
     "pseudopotential": "100PAW",
     "cutoff_wfc": 91.0,
@@ -1400,7 +1400,7 @@
     ]
   },
   "U": {
-    "filename": "pseudo_install/U.rel-pbe-spfn-kjpaw_psl.1.0.0.UPF",
+    "filename": "U.rel-pbe-spfn-kjpaw_psl.1.0.0.UPF",
     "md5": "cdc9612a36cd57600ea475b5246d9738",
     "pseudopotential": "100PAW",
     "cutoff_wfc": 93.0,
@@ -1418,7 +1418,7 @@
     ]
   },
   "Np": {
-    "filename": "pseudo_install/Np.rel-pbe-spfn-kjpaw_psl.1.0.0.UPF",
+    "filename": "Np.rel-pbe-spfn-kjpaw_psl.1.0.0.UPF",
     "md5": "35915e68fa6a4b3a8cbe18e970f64960",
     "pseudopotential": "100PAW",
     "cutoff_wfc": 111.0,
@@ -1436,7 +1436,7 @@
     ]
   },
   "Pu": {
-    "filename": "pseudo_install/Pu.rel-pbe-spfn-kjpaw_psl.1.0.0.UPF",
+    "filename": "Pu.rel-pbe-spfn-kjpaw_psl.1.0.0.UPF",
     "md5": "e010d28413c0ccffc9c18da7c0afce86",
     "pseudopotential": "100PAW",
     "cutoff_wfc": 45.0,


### PR DESCRIPTION
1. Update the pslibrary installation script `src/aiida_wannier90_workflows/utils/pseudo/data/__init__.py` and the pslibrary semicore file `src/aiida_wannier90_workflows/utils/pseudo/data/semicore/pslibrary_paw_relpbe_1.0.0.json`. Now the 'filename' in the semicore file is pure filename without path information.
2. Change the location where values are assigned to nspin to avoid repeat assignments.